### PR TITLE
🐛 :: 도로 콜라이더 변경

### DIFF
--- a/Assets/01_Scripts/GamePlay/Field/Road.cs
+++ b/Assets/01_Scripts/GamePlay/Field/Road.cs
@@ -9,7 +9,8 @@ public class Road : MonoBehaviour
     public float playerBackSpaceLength;
 
     private MeshFilter meshFilter;
-    private MeshCollider meshCollider;
+    //private MeshCollider meshCollider;
+    private BoxCollider boxCollider;
     public Mesh curruntRoadMesh { get; private set; }
     private float originRoadMeshMinZ;
     private float originRoadMeshLength;
@@ -19,7 +20,8 @@ public class Road : MonoBehaviour
     private void Awake()
     {
         meshFilter = GetComponent<MeshFilter>();
-        meshCollider = GetComponent<MeshCollider>();
+        //meshCollider = GetComponent<MeshCollider>();
+        boxCollider = GetComponent<BoxCollider>();
     }
 
     private void Start()
@@ -51,6 +53,11 @@ public class Road : MonoBehaviour
         lastSummonedMeshMinZ = -playerBackSpaceLength;
         curruntRoadMesh = new Mesh() { name = "Road" };
 
+        Vector3 size = originRoadMesh.bounds.size;
+        size.z *= roadMeshCount;
+        boxCollider.size = size;
+        boxCollider.center = new Vector3(-originRoadMesh.bounds.size.x / 2, -originRoadMesh.bounds.size.y / 2, 0);
+
         for (int i = 0; i < roadMeshCount; i++)
         {
             MoveMesh();
@@ -72,15 +79,18 @@ public class Road : MonoBehaviour
         (curruntRoadMesh, _) = MeshUtil.Cut(curruntRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount), Vector3.back);
 
         meshFilter.sharedMesh = curruntRoadMesh;
-        meshCollider.sharedMesh = curruntRoadMesh;
+        //meshCollider.sharedMesh = curruntRoadMesh;
 
+        Vector3 centor = boxCollider.center;
+        centor.z = lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount / 2;
+        boxCollider.center = centor;
     }
 
     public void SetMesh(Mesh mesh)
     {
         curruntRoadMesh = mesh;
         meshFilter.sharedMesh = curruntRoadMesh;
-        meshCollider.sharedMesh = curruntRoadMesh;
+        //meshCollider.sharedMesh = curruntRoadMesh;
     }
 
 #if UNITY_EDITOR

--- a/Assets/03_Prefabs/Road.prefab
+++ b/Assets/03_Prefabs/Road.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2408760895863150969}
   - component: {fileID: 2408760895863150972}
   - component: {fileID: 2408760895863150971}
-  - component: {fileID: 2408760895863150970}
+  - component: {fileID: 7824395715092347955}
   m_Layer: 6
   m_Name: Road
   m_TagString: Road
@@ -100,8 +100,8 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &2408760895863150970
-MeshCollider:
+--- !u!65 &7824395715092347955
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -110,7 +110,6 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 0}
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/04_SO/플레이어 설정.asset
+++ b/Assets/04_SO/플레이어 설정.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61d8d61f0d4685946991758c9ff36adf, type: 3}
   m_Name: "\uD50C\uB808\uC774\uC5B4 \uC124\uC815"
   m_EditorClassIdentifier: 
-  minX: -5
-  maxX: 5
+  minX: -4.75
+  maxX: 4.75
   fallingSensorY: -0.5
   _moveSpeed: 15
   _jumpPower: 5


### PR DESCRIPTION
메시의 가장자리가 약간 올라와 있어 플레이어가 걸쳐있을 때 점프가 안되는 문제 수정
-> 도로 콜라이더를 메시 콜라이더에서 박스로 변경
플레이어가 한쪽 끝으로 붙으면 스파이크를 피할 수 있는 버그 수정