### PR TITLE
🐛 :: 첫 장애물이 점수에 상관없이 나오는 버그 수정

### DIFF
--- a/Assets/01_Scripts/GamePlay/Player/Player.cs
+++ b/Assets/01_Scripts/GamePlay/Player/Player.cs
@@ -90,7 +90,6 @@ public class Player : MonoBehaviour
     {
         SetGoldRate();
         OnChangedBoostGazy?.Invoke(0);
-        GameManager.Instance.GemScore = 0;
     }
 
     protected virtual void Update()

--- a/Assets/01_Scripts/Spawner/PlayerSpawner.cs
+++ b/Assets/01_Scripts/Spawner/PlayerSpawner.cs
@@ -25,6 +25,9 @@ public class PlayerSpawner : MonoBehaviour
 
     private void Start()
     {
+        GameManager.Instance.GemScore = 0;
+        GameManager.Instance.DistanceScore = 0;
+
         SpawnHandler();
     }
 


### PR DESCRIPTION
PlayerSpawner의 Start에서 플레이어 스폰이 1틱에 진행
Player의 Start에서의 점수 초기화와 ObstacleSpawner의 Update에서의 장애물 스폰이 2틱에 진행

점수 초기화와 장애물 스폰의 시점이 겹쳐 첫 장애물만 점수 상관없이 스폰되고있었음