### PR TITLE
메모리 누수 해결

### DIFF
--- a/Assets/01_Scripts/GamePlay/Field/Road.cs
+++ b/Assets/01_Scripts/GamePlay/Field/Road.cs
@@ -11,7 +11,7 @@ public class Road : MonoBehaviour
 
     private MeshFilter meshFilter;
     private MeshCollider meshCollider;
-    public Mesh curruntRoadMesh { get; private set; }
+    public Mesh currentRoadMesh { get; private set; }
     private float originRoadMeshMinZ;
     private float originRoadMeshLength;
 
@@ -33,7 +33,7 @@ public class Road : MonoBehaviour
         }
 
         Mesh copiedOriginRoadMesh = new Mesh();
-        copiedOriginRoadMesh.name = "Copyied originRoadMesh";
+        copiedOriginRoadMesh.name = "Copied originRoadMesh";
         copiedOriginRoadMesh.vertices = originRoadMesh.vertices;
         copiedOriginRoadMesh.triangles = originRoadMesh.triangles;
         copiedOriginRoadMesh.normals = originRoadMesh.normals;
@@ -69,7 +69,7 @@ public class Road : MonoBehaviour
         }
         originRoadMeshLength = maxZ - originRoadMeshMinZ;
         lastSummonedMeshMinZ = -playerBackSpaceLength;
-        curruntRoadMesh = new Mesh() { name = "Road" };
+        currentRoadMesh = new Mesh() { name = "Road" };
 
         for (int i = 0; i < roadMeshCount; i++)
         {
@@ -87,21 +87,21 @@ public class Road : MonoBehaviour
 
     private void MoveMesh()
     {
-        MeshData curruntRoadMeshData = MeshUtil.Merge(MeshData.MeshToData(curruntRoadMesh), MeshData.MeshToData(originRoadMesh), new Vector3(0, 0, lastSummonedMeshMinZ));
+        MeshData curruntRoadMeshData = MeshUtil.Merge(MeshData.MeshToData(currentRoadMesh), MeshData.MeshToData(originRoadMesh), new Vector3(0, 0, lastSummonedMeshMinZ));
         lastSummonedMeshMinZ += originRoadMeshLength;
 
         (curruntRoadMeshData, _) = MeshUtil.Cut(curruntRoadMeshData, new Vector3(0, 0, lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount), Vector3.back);
-        curruntRoadMeshData.DataToMesh(curruntRoadMesh);
+        curruntRoadMeshData.DataToMesh(currentRoadMesh);
 
-        meshFilter.sharedMesh = curruntRoadMesh;
-        meshCollider.sharedMesh = curruntRoadMesh;
+        meshFilter.sharedMesh = currentRoadMesh;
+        meshCollider.sharedMesh = currentRoadMesh;
     }
 
     public void SetMesh(MeshData mesh)
     {
-        mesh.DataToMesh(curruntRoadMesh);
-        meshFilter.sharedMesh = curruntRoadMesh;
-        meshCollider.sharedMesh = curruntRoadMesh;
+        mesh.DataToMesh(currentRoadMesh);
+        meshFilter.sharedMesh = currentRoadMesh;
+        meshCollider.sharedMesh = currentRoadMesh;
     }
 
 #if UNITY_EDITOR
@@ -114,7 +114,7 @@ public class Road : MonoBehaviour
                 float roadLength = originRoadMesh.bounds.max.z - originRoadMesh.bounds.min.z;
                 Gizmos.DrawMesh(originRoadMesh, new Vector3(-originRoadMesh.bounds.center.x, transform.position.y, roadLength * i));
             }
-            Gizmos.DrawWireMesh(curruntRoadMesh, transform.position);
+            Gizmos.DrawWireMesh(currentRoadMesh, transform.position);
         }
     }
 #endif

--- a/Assets/01_Scripts/GamePlay/Field/Road.cs
+++ b/Assets/01_Scripts/GamePlay/Field/Road.cs
@@ -86,8 +86,8 @@ public class Road : MonoBehaviour
     }
 
     private void MoveMesh()
-    {
-        curruntRoadMesh = MeshUtil.Merge(curruntRoadMesh, originRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ));
+    {   
+        MeshUtil.Merge(curruntRoadMesh, originRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ));
         lastSummonedMeshMinZ += originRoadMeshLength;
 
         (curruntRoadMesh, _) = MeshUtil.Cut(curruntRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount), Vector3.back);

--- a/Assets/01_Scripts/GamePlay/Field/Road.cs
+++ b/Assets/01_Scripts/GamePlay/Field/Road.cs
@@ -86,21 +86,20 @@ public class Road : MonoBehaviour
     }
 
     private void MoveMesh()
-    {   
-        MeshUtil.Merge(curruntRoadMesh, originRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ));
+    {
+        MeshData curruntRoadMeshData = MeshUtil.Merge(MeshData.MeshToData(curruntRoadMesh), MeshData.MeshToData(originRoadMesh), new Vector3(0, 0, lastSummonedMeshMinZ));
         lastSummonedMeshMinZ += originRoadMeshLength;
 
-        (curruntRoadMesh, _) = MeshUtil.Cut(curruntRoadMesh, new Vector3(0, 0, lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount), Vector3.back);
+        (curruntRoadMeshData, _) = MeshUtil.Cut(curruntRoadMeshData, new Vector3(0, 0, lastSummonedMeshMinZ - originRoadMeshLength * roadMeshCount), Vector3.back);
+        curruntRoadMeshData.DataToMesh(curruntRoadMesh);
 
         meshFilter.sharedMesh = curruntRoadMesh;
         meshCollider.sharedMesh = curruntRoadMesh;
-
-        curruntRoadMesh.RecalculateBounds();
     }
 
-    public void SetMesh(Mesh mesh)
+    public void SetMesh(MeshData mesh)
     {
-        curruntRoadMesh = mesh;
+        mesh.DataToMesh(curruntRoadMesh);
         meshFilter.sharedMesh = curruntRoadMesh;
         meshCollider.sharedMesh = curruntRoadMesh;
     }

--- a/Assets/01_Scripts/GamePlay/Field/SinkHole/SinkHole.cs
+++ b/Assets/01_Scripts/GamePlay/Field/SinkHole/SinkHole.cs
@@ -74,7 +74,8 @@ public class SinkHole : ObjectPoolable
         (before, middle) = MeshUtil.Cut(mesh, centor + Vector3.forward * startZ, Vector3.forward);
         (after, middle) = MeshUtil.Cut(middle, centor + Vector3.forward * (startZ + HoleDistance), Vector3.back, generateFrontWall, cuttedSliceUV);
 
-        Mesh result = MeshUtil.Merge(before, after);
+        Mesh result = before;
+        MeshUtil.Merge(result, after);
         Vector3 leftPoint = new Vector3(startX1, 0, startZ) + centor;
         Vector3 rightPoint = new Vector3(startX2, 0, startZ) + centor;
         Vector3 leftNormal = Vector3.Cross(leftPoint - new Vector3(endX1, 0, startZ + HoleDistance) - centor, Vector3.down);
@@ -84,16 +85,16 @@ public class SinkHole : ObjectPoolable
         {
             Mesh temp1, temp2;
             (temp1, _) = MeshUtil.Cut(middle, leftPoint, -leftNormal, true, cuttedSliceUV);
-            result = MeshUtil.Merge(result, temp1);
+            MeshUtil.Merge(result, temp1);
             (temp2, _) = MeshUtil.Cut(middle, rightPoint, -rightNormal, true, cuttedSliceUV);
-            result = MeshUtil.Merge(result, temp2);
+            MeshUtil.Merge(result, temp2);
         }
         else
         {
             Mesh temp;
             (temp, _) = MeshUtil.Cut(middle, leftPoint, leftNormal, true, cuttedSliceUV);
             (temp, _) = MeshUtil.Cut(temp, rightPoint, rightNormal, true, cuttedSliceUV);
-            result = MeshUtil.Merge(result, temp);
+            MeshUtil.Merge(result, temp);
 
             Mesh wallMesh = new Mesh();
             wallMesh.vertices = new Vector3[] {
@@ -105,7 +106,7 @@ public class SinkHole : ObjectPoolable
             wallMesh.triangles = new int[] { 0, 1, 2, 1, 3, 2 };
             wallMesh.normals = new Vector3[] { Vector3.right, Vector3.right, Vector3.right, Vector3.right };
             wallMesh.uv = new Vector2[] { cuttedSliceUV, cuttedSliceUV, cuttedSliceUV, cuttedSliceUV };
-            result = MeshUtil.Merge(result, wallMesh);
+            MeshUtil.Merge(result, wallMesh);
         }
 
         Mesh floorMesh = new Mesh();
@@ -118,7 +119,7 @@ public class SinkHole : ObjectPoolable
         floorMesh.triangles = new int[] { 0, 1, 2, 1, 3, 2 };
         floorMesh.normals = new Vector3[] { Vector3.up, Vector3.up, Vector3.up, Vector3.up };
         floorMesh.uv = new Vector2[] { cuttedSliceUV, cuttedSliceUV, cuttedSliceUV, cuttedSliceUV };
-        result = MeshUtil.Merge(result, floorMesh);
+        MeshUtil.Merge(result, floorMesh);
 
 
         return result;

--- a/Assets/01_Scripts/GamePlay/Field/SinkHole/SinkHole.cs
+++ b/Assets/01_Scripts/GamePlay/Field/SinkHole/SinkHole.cs
@@ -36,12 +36,12 @@ public class SinkHole : ObjectPoolable
                     {
                         float distance = Random.Range(minDistance, maxDistance);
 
-                        if (transform.position.z - road.transform.position.z + totalDistance + distance > road.curruntRoadMesh.bounds.max.z - maxDistance)
+                        if (transform.position.z - road.transform.position.z + totalDistance + distance > road.currentRoadMesh.bounds.max.z - maxDistance)
                         {
                             i = count - 1;
                         }
 
-                        MeshData cutRoadData = CutRoad(MeshData.MeshToData(road.curruntRoadMesh),
+                        MeshData cutRoadData = CutRoad(MeshData.MeshToData(road.currentRoadMesh),
                             isHole,
                             transform.position.z - road.transform.position.z + totalDistance,
                             distance,


### PR DESCRIPTION
메쉬 절단/병합시 새로운 Mesh 객체를 만들어 반환하는데, Mesh객체는 참조가 사라져도 GC가 메모리 해제를 안함
MeshData 구조체로 데이터를 전달해 새로운 Mesh를 만들지 않고 기존 Mesh를 편집하는 방식으로 해결